### PR TITLE
[FIX] 파싱에 사용된 모든 동적할당 free

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@
 # **************************************************************************** #
 
 CC			= cc
-WFLAG		= -Wall -Wextra -Werror
+# WFLAG		= -Wall -Wextra -Werror
 LIBFT		= -Llibft -lft
 # READLINE	= -L/usr/local/lib  -lreadline
 READLINE	= -L/opt/homebrew/Cellar/readline/8.2.7/lib -lreadline

--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,8 @@
 CC			= cc
 WFLAG		= -Wall -Wextra -Werror
 LIBFT		= -Llibft -lft
-READLINE	= -L/usr/local/lib  -lreadline
-# READLINE	= -L/opt/homebrew/Cellar/readline/8.2.7/lib -lreadline
+# READLINE	= -L/usr/local/lib  -lreadline
+READLINE	= -L/opt/homebrew/Cellar/readline/8.2.7/lib -lreadline
 
 DIR			= ./
 BASE		= main signal_utils \

--- a/btin/btin_env.c
+++ b/btin/btin_env.c
@@ -12,6 +12,21 @@
 
 #include "../minishell.h"
 
+void	btin_free_envsp(t_envs *envsp)
+{
+	t_envs	*node;
+
+	while (envsp)
+	{
+		node = envsp;
+		free(node->key);
+		if (node->value)
+			free(node->value);
+		envsp = envsp->next;
+		free(node);
+	}
+}
+
 void	btin_env(t_envs *envsp, int fork_flag)
 {
 	t_envs	*node;

--- a/legacy/readme.md
+++ b/legacy/readme.md
@@ -15,4 +15,4 @@
 - [ ] norm 맞추기
 
 ### Issue List (찾으면 일단 적기!)
-- [ ] execve에 빈 word 배열 넘길 때 segfault 나는 것 고치기
+- [X] execve에 빈 word 배열 넘길 때 segfault 나는 것 고치기

--- a/main.c
+++ b/main.c
@@ -41,9 +41,14 @@ int	jump_white_space(char *str)
 	return (1);
 }
 
+void	leaks_test()
+{
+	system("leaks --list minishell");
+}
+
 void	parser_info_free(t_parser_info *p_info)
 {
-	
+	free(p_info->line);
 }
 
 int	main(int argc, char **argv, char **envp)
@@ -51,6 +56,7 @@ int	main(int argc, char **argv, char **envp)
 	t_envs			*envsp;
 	t_parser_info	p_info;
 
+	atexit(leaks_test);
 	argc = argv - argv + argc;
 	terminal_print_off();
 	set_signal(MODE_SHELL, MODE_SHELL);
@@ -67,7 +73,7 @@ int	main(int argc, char **argv, char **envp)
 				if (!mktr_make_tree(p_info.tk_head, &(p_info.root)))
 					if (!trtv_expansion_travel(p_info.root, envsp))
 						trtv_list_travel(p_info.root, envsp);
-		free(p_info.line);
+		parser_info_free(&p_info);
 	}
 	terminal_print_on();
 }

--- a/main.c
+++ b/main.c
@@ -79,9 +79,9 @@ int	main(int argc, char **argv, char **envp)
 		if (*(p_info.line) != 0)
 			add_history(p_info.line);
 		if (*(p_info.line) != 0 && !jump_white_space(p_info.line))
-			if (!tk_tokenize(p_info.line, &(p_info.tk_head)));
-				// if (!mktr_make_tree(p_info.tk_head, &(p_info.root)))
-				// 	if (!trtv_expansion_travel(p_info.root, envsp))
+			if (!tk_tokenize(p_info.line, &(p_info.tk_head)))
+				if (!mktr_make_tree(p_info.tk_head, &(p_info.root)))
+					if (!trtv_expansion_travel(p_info.root, envsp));
 				// 		trtv_list_travel(p_info.root, envsp);
 		parser_info_free(&p_info);
 	}

--- a/main.c
+++ b/main.c
@@ -105,8 +105,8 @@ int	main(int argc, char **argv, char **envp)
 		if (*(p_info.line) != 0 && !jump_white_space(p_info.line))
 			if (!tk_tokenize(p_info.line, &(p_info.tk_head)))
 				if (!mktr_make_tree(p_info.tk_head, &(p_info.root)))
-					if (!trtv_expansion_travel(p_info.root, envsp));
-				// 		trtv_list_travel(p_info.root, envsp);
+					if (!trtv_expansion_travel(p_info.root, envsp))
+						trtv_list_travel(p_info.root, envsp);
 		parser_info_free(&p_info);
 	}
 	btin_free_envsp(envsp);

--- a/main.c
+++ b/main.c
@@ -48,7 +48,17 @@ void	leaks_test()
 
 void	parser_info_free(t_parser_info *p_info)
 {
+	t_token	*t_node;
+
 	free(p_info->line);
+	t_node = p_info->tk_head;
+	while (p_info->tk_head)
+	{
+		t_node = p_info->tk_head;
+		free(t_node->str);
+		p_info->tk_head = p_info->tk_head->next;
+		free(t_node);
+	}
 }
 
 int	main(int argc, char **argv, char **envp)
@@ -69,11 +79,12 @@ int	main(int argc, char **argv, char **envp)
 		if (*(p_info.line) != 0)
 			add_history(p_info.line);
 		if (*(p_info.line) != 0 && !jump_white_space(p_info.line))
-			if (!tk_tokenize(p_info.line, &(p_info.tk_head)))
-				if (!mktr_make_tree(p_info.tk_head, &(p_info.root)))
-					if (!trtv_expansion_travel(p_info.root, envsp))
-						trtv_list_travel(p_info.root, envsp);
+			if (!tk_tokenize(p_info.line, &(p_info.tk_head)));
+				// if (!mktr_make_tree(p_info.tk_head, &(p_info.root)))
+				// 	if (!trtv_expansion_travel(p_info.root, envsp))
+				// 		trtv_list_travel(p_info.root, envsp);
 		parser_info_free(&p_info);
 	}
+	btin_free_envsp(envsp);
 	terminal_print_on();
 }

--- a/main.c
+++ b/main.c
@@ -104,8 +104,8 @@ int	main(int argc, char **argv, char **envp)
 			add_history(p_info.line);
 		if (*(p_info.line) != 0 && !jump_white_space(p_info.line))
 			if (!tk_tokenize(p_info.line, &(p_info.tk_head)))
-				if (!mktr_make_tree(p_info.tk_head, &(p_info.root)));
-					// if (!trtv_expansion_travel(p_info.root, envsp))
+				if (!mktr_make_tree(p_info.tk_head, &(p_info.root)))
+					if (!trtv_expansion_travel(p_info.root, envsp));
 				// 		trtv_list_travel(p_info.root, envsp);
 		parser_info_free(&p_info);
 	}

--- a/main.c
+++ b/main.c
@@ -46,6 +46,29 @@ void	leaks_test()
 	system("leaks --list minishell");
 }
 
+void	trtv_free(t_tr_node *node)
+{
+	int	i;
+
+
+	if (node->left)
+		trtv_free(node->left);
+	if (node->right)
+		trtv_free(node->right);
+	if (node->word_split.items)
+	{
+		i = 0;
+		while (i < node->word_split.size)
+		{
+			if (node->word_split.items[i])
+				free(node->word_split.items[i]);
+			i++;	
+		}	
+		vec_free(&(node->word_split));
+	}
+	free (node);
+}
+
 void	parser_info_free(t_parser_info *p_info)
 {
 	t_token	*t_node;
@@ -59,6 +82,7 @@ void	parser_info_free(t_parser_info *p_info)
 		p_info->tk_head = p_info->tk_head->next;
 		free(t_node);
 	}
+
 }
 
 int	main(int argc, char **argv, char **envp)
@@ -80,8 +104,8 @@ int	main(int argc, char **argv, char **envp)
 			add_history(p_info.line);
 		if (*(p_info.line) != 0 && !jump_white_space(p_info.line))
 			if (!tk_tokenize(p_info.line, &(p_info.tk_head)))
-				if (!mktr_make_tree(p_info.tk_head, &(p_info.root)))
-					if (!trtv_expansion_travel(p_info.root, envsp));
+				if (!mktr_make_tree(p_info.tk_head, &(p_info.root)));
+					// if (!trtv_expansion_travel(p_info.root, envsp))
 				// 		trtv_list_travel(p_info.root, envsp);
 		parser_info_free(&p_info);
 	}

--- a/main.c
+++ b/main.c
@@ -50,11 +50,10 @@ void	trtv_free(t_tr_node *node)
 {
 	int	i;
 
-
-	if (node->left)
-		trtv_free(node->left);
-	if (node->right)
-		trtv_free(node->right);
+	if (!node)
+		return ;
+	trtv_free(node->left);
+	trtv_free(node->right);
 	if (node->word_split.items)
 	{
 		i = 0;
@@ -97,6 +96,7 @@ int	main(int argc, char **argv, char **envp)
 	envsp = btin_make_envsp(envp);
 	while (1)
 	{
+		ft_bzero(&p_info, sizeof(t_parser_info));
 		p_info.line = readline("minishell $ ");
 		if (!(p_info.line))
 			break ;

--- a/main.c
+++ b/main.c
@@ -82,7 +82,7 @@ void	parser_info_free(t_parser_info *p_info)
 		p_info->tk_head = p_info->tk_head->next;
 		free(t_node);
 	}
-
+	trtv_free(p_info->root);
 }
 
 int	main(int argc, char **argv, char **envp)

--- a/minishell.h
+++ b/minishell.h
@@ -155,6 +155,7 @@ void			btin_export_print(t_envs *envsp);
 void			btin_free_key_and_value(char **key_and_value, char *key, char *value);
 t_envs			*btin_make_envsp_node(char **key_and_value);
 t_envs			*btin_make_envsp(char **envp);
+void			btin_free_envsp(t_envs *envsp);
 t_envs			*btin_find_node(t_envs *envsp, char *key);
 char			**btin_divide_key_and_value(char *env);
 char			*btin_make_errmsg(char *s1, char *s2, char *s3);

--- a/parser/mktr.c
+++ b/parser/mktr.c
@@ -145,6 +145,6 @@ int	mktr_make_tree(t_token *tk_head, t_tr_node **root)
 		if (tk_now->type != T_NEWLINE)
 			return (mktr_print_unexpected(tk_now->str));
 	}
-	// return (0);
-	return (test_tr_print_tree(*root, "INIT TREE"));
+	return (0);
+	// return (test_tr_print_tree(*root, "INIT TREE"));
 }

--- a/parser/mktr.c
+++ b/parser/mktr.c
@@ -145,6 +145,7 @@ int	mktr_make_tree(t_token *tk_head, t_tr_node **root)
 		if (tk_now->type != T_NEWLINE)
 			return (mktr_print_unexpected(tk_now->str));
 	}
+	vec_free(&(info.hdocs));
 	return (0);
 	// return (test_tr_print_tree(*root, "INIT TREE"));
 }

--- a/parser/trtv_env_expand.c
+++ b/parser/trtv_env_expand.c
@@ -57,6 +57,7 @@ static int	trtv_dollar_sign(char *word, int now, char **e_w, t_envs *envsp)
 	if (!btin_find_node(envsp, key))
 		return (len);
 	value = ft_strdup_s(btin_find_node(envsp, key)->value);
+	free(key);
 	i = 0;
 	while (value[i])
 	{


### PR DESCRIPTION
## Summary
파싱에 사용된 모든 동적할당 free, 그리고 _"[FIX] 실행부에 넘겨준 list에 사용된 동적할당 free #8"_ 에서 최종적으로 모든 leaks를 잡기 위해 merge 하려고 합니다.
## Description
- `btin_free_envsp`함수를 통해서 프로그램 마지막에 envsp를 모두 free합니다.
- `parser_info_free`함수를 통해서 token list를 모두 free하고 tree free를 시작합니다. 최종적으로 line도 free합니다.
- `trtv_free`를 통해서 tree를 전위순회하며 내용과 노드를 free합니다.
- 추가적으로 아래의 함수를 통해 leaks 검사를 수행합니다.
```c
void	leaks_test()
{
	system("leaks --list minishell");
}
```
- 실행부 직전까지에 대한 leaks 검사 수행결과는 아래와 같습니다.
```bash
minishell $ ec$a $a | ec$a $a
minishell $
Process:         minishell [86827]
Path:            /Volumes/VOLUME/*/minishell
Load Address:    0x10b555000
Identifier:      minishell
Version:         ???
Code Type:       X86-64
Parent Process:  zsh [81593]

Date/Time:       2024-01-20 16:46:00.527 +0900
Launch Time:     2024-01-20 16:45:50.210 +0900
OS Version:      Mac OS X 10.15.7 (19H15)
Report Version:  7
Analysis Tool:   /Applications/Xcode.app/Contents/Developer/usr/bin/leaks
Analysis Tool Version:  Xcode 12.3 (12C33)

Physical footprint:         792K
Physical footprint (peak):  792K
----

leaks Report Version: 3.0
Process 86827: 376 nodes malloced for 358 KB
Process 86827: 0 leaks for 0 total leaked bytes.
```