### PR TITLE
[FIX] 명령어로 '\0'이 들어오면 "/usr/bin"로 교체되는 문제

### DIFF
--- a/execute/ex_execute.c
+++ b/execute/ex_execute.c
@@ -6,7 +6,7 @@
 /*   By: seonjo <seonjo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/01/10 17:12:59 by seonjo            #+#    #+#             */
-/*   Updated: 2024/01/19 15:08:20 by seonjo           ###   ########.fr       */
+/*   Updated: 2024/01/23 15:24:26 by seonjo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -105,7 +105,7 @@ void	ex_execute(char **cmd, t_envs *envsp, char **envp)
 	if (ft_strncmp(cmd[0], ".", 2) == 0)
 		btin_out(1, 2, btin_make_errmsg("minishell: ", cmd[0], \
 			"filename argument required\n.: usage: . filename [arguments]"));
-	else if (ft_strncmp(cmd[0], "..", 3) == 0)
+	else if (ft_strncmp(cmd[0], "..", 3) == 0 || cmd[0][0] == '\0')
 		btin_out(1, 127, btin_make_errmsg("minishell: ", cmd[0], \
 			"command not found"));
 	if (ex_is_directory(cmd[0]) == 1 && ex_is_path(cmd[0]) == 1)


### PR DESCRIPTION
## Summary
명령어로 '\0'이 들어오면 "/usr/bin"로 교체되는 문제해결

## Description
- 만약 cmd[0]에 "\0"이 들어온 경우 command not found 에러를 발생시키는 조건문 추가
```c
	else if (ft_strncmp(cmd[0], "..", 3) == 0 || cmd[0][0] == '\0')
		btin_out(1, 127, btin_make_errmsg("minishell: ", cmd[0], \
			"command not found"));
```
