### PR TITLE
[FIX] 실행부에서 발생하는 메모리 누수 전부 막기 + 사소한 에러 처리

### DIFF
--- a/btin/btin_cd.c
+++ b/btin/btin_cd.c
@@ -29,7 +29,7 @@ void	btin_modify_pwd(t_envs *envsp, char *old_pwd, int fork_flag)
 	{
 		pwd = getcwd(NULL, 1024);
 		if (pwd == NULL)
-			btin_out(1, errno, btin_make_errmsg("minishell: ", \
+			btin_out(1, errno, btin_make_errmsg("minishell: cd: ", \
 				"getcwd", strerror(errno)));
 		free(env_pwd->value);
 		env_pwd->value = pwd;
@@ -69,17 +69,17 @@ void	btin_move_to_dest(t_envs *envsp, char *dest, int fork_flag)
 
 	pwd = getcwd(NULL, 1024);
 	if (pwd == NULL)
-		btin_out(1, errno, btin_make_errmsg("minishell: ", \
+		btin_out(1, errno, btin_make_errmsg("minishell: cd: ", \
 			"getcwd", strerror(errno)));
 	if (stat(dest, &dir_stat) == -1)
-		btin_out(1, errno, btin_make_errmsg("minishell: ", \
+		btin_out(1, errno, btin_make_errmsg("minishell: cd: ", \
 		"stat", strerror(errno)));
 	else if (S_ISDIR(dir_stat.st_mode) != 1)
 		btin_cd_error(2, dest, pwd, fork_flag);
 	else if (access(dest, X_OK) != 0)
 		btin_cd_error(3, dest, pwd, fork_flag);
 	else if (chdir(dest) == -1)
-		btin_out(1, errno, btin_make_errmsg("minishell: ", \
+		btin_out(1, errno, btin_make_errmsg("minishell: cd: ", \
 		"chdir", strerror(errno)));
 	else
 	{

--- a/btin/btin_cd.c
+++ b/btin/btin_cd.c
@@ -25,6 +25,8 @@ void	btin_modify_pwd(t_envs *envsp, char *old_pwd, int fork_flag)
 		free(env_oldpwd->value);
 		env_oldpwd->value = old_pwd;
 	}
+	else
+		free(old_pwd);
 	if (env_pwd != NULL)
 	{
 		pwd = getcwd(NULL, 1024);

--- a/btin/btin_exit.c
+++ b/btin/btin_exit.c
@@ -6,7 +6,7 @@
 /*   By: seonjo <seonjo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/01/05 10:55:22 by seonjo            #+#    #+#             */
-/*   Updated: 2024/01/19 16:14:53 by seonjo           ###   ########.fr       */
+/*   Updated: 2024/01/23 15:47:17 by seonjo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -34,7 +34,7 @@ long long	btin_is_overflow(long long num, int n, long long minus)
 	return (0);
 }
 
-long long	btin_atoi(char *str)
+long long	btin_atoi(t_cmds *cmds, char *str)
 {
 	long long	minus;
 	long long	num;
@@ -45,16 +45,19 @@ long long	btin_atoi(char *str)
 		str++;
 	str = btin_sign_check(str, &minus);
 	if (!(*str >= '0' && *str <= '9'))
-		return (-1);
+		btin_out(1, 255, btin_make_errmsg("minishell: exit: ", \
+			(char *)cmds->argv.items[1], "numeric argument required"));
 	while (*str >= '0' && *str <= '9')
 	{
 		if (btin_is_overflow(num, *str - '0', minus) == 1)
-			return (-1);
+			btin_out(1, 255, btin_make_errmsg("minishell: exit: ", \
+				(char *)cmds->argv.items[1], "numeric argument required"));
 		num = num * 10 + *str - '0';
 		str++;
 	}
 	if (*str != '\0')
-		return (-1);
+		btin_out(1, 255, btin_make_errmsg("minishell: exit: ", \
+				(char *)cmds->argv.items[1], "numeric argument required"));
 	return (num * minus);
 }
 
@@ -82,13 +85,8 @@ void	btin_exit(t_cmds *cmds, int fork_flag)
 		btin_out(1, 0, NULL);
 	else
 	{
-		n = btin_atoi(cmds->argv.items[1]);
-		if (n == -1)
-		{
-			btin_out(1, 255, btin_make_errmsg("minishell: exit: ", \
-				(char *)cmds->argv.items[1], "numeric argument required"));
-		}
-		else if (cmds->argv.items[2] != NULL)
+		n = btin_atoi(cmds, cmds->argv.items[1]);
+		if (cmds->argv.items[2] != NULL)
 			btin_out(fork_flag, 1, btin_make_errmsg("minishell: ", \
 				"exit", "too many arguments"));
 		else

--- a/btin/btin_export.c
+++ b/btin/btin_export.c
@@ -81,8 +81,10 @@ void	btin_export(t_cmds *cmds, t_envs *envsp, int error_code, int fork_flag)
 			else
 			{
 				btin_free_key_and_value(key_value, key_value[0], key_value[1]);
-				btin_out(0, 0, btin_make_errmsg("minishell: export: '", \
-					ft_strjoin_s(str, "'"), "not a valid identifier"));
+				str = ft_strjoin_s(str, "'");
+				btin_out(0, 0, btin_make_errmsg("minishell: export: '", str, \
+					"not a valid identifier"));
+				free(str);
 				error_code = 1;
 			}
 		}

--- a/btin/btin_export.c
+++ b/btin/btin_export.c
@@ -55,11 +55,10 @@ void	btin_traverse_list_to_add(t_envs *envsp, char **key_and_value)
 		if (target->value != NULL)
 			free(target->value);
 		target->value = key_and_value[1];
-		free(key_and_value[0]);
+		btin_free_key_and_value(key_and_value, key_and_value[0], NULL);
 	}
 	else
-		free(key_and_value[0]);
-	free(key_and_value);
+		btin_free_key_and_value(key_and_value, key_and_value[0], NULL);
 }
 
 void	btin_export(t_cmds *cmds, t_envs *envsp, int error_code, int fork_flag)

--- a/btin/btin_export.c
+++ b/btin/btin_export.c
@@ -28,23 +28,19 @@ t_envs	*btin_find_node(t_envs *envsp, char *key)
 	return (NULL);
 }
 
-void	btin_add_new_node(t_envs *now, char **key_and_value)
+void	btin_add_new_node(t_envs *envsp, char **key_and_value)
 {
+	t_envs	*now;
 	t_envs	*next;
 
-	if (now == NULL)
-		now->next = btin_make_envsp_node(key_and_value);
-	else
+	now = envsp;
+	next = now->next;
+	while (next != NULL)
 	{
+		now = next;
 		next = now->next;
-		while (next->next != NULL)
-		{
-			now = next;
-			next = next->next;
-		}
-		now->next = btin_make_envsp_node(key_and_value);
-		now->next->next = next;
 	}
+	now->next = btin_make_envsp_node(key_and_value);
 }
 
 void	btin_traverse_list_to_add(t_envs *envsp, char **key_and_value)
@@ -53,15 +49,17 @@ void	btin_traverse_list_to_add(t_envs *envsp, char **key_and_value)
 
 	target = btin_find_node(envsp, key_and_value[0]);
 	if (target == NULL)
-		btin_add_new_node(envsp->next, key_and_value);
+		btin_add_new_node(envsp, key_and_value);
 	else if (key_and_value[1] != NULL)
 	{
 		if (target->value != NULL)
 			free(target->value);
 		target->value = key_and_value[1];
 		free(key_and_value[0]);
-		free(key_and_value);
 	}
+	else
+		free(key_and_value[0]);
+	free(key_and_value);
 }
 
 void	btin_export(t_cmds *cmds, t_envs *envsp, int error_code, int fork_flag)

--- a/btin/btin_make_envsp.c
+++ b/btin/btin_make_envsp.c
@@ -6,7 +6,7 @@
 /*   By: seonjo <seonjo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/16 16:25:24 by seonjo            #+#    #+#             */
-/*   Updated: 2024/01/23 16:21:36 by seonjo           ###   ########.fr       */
+/*   Updated: 2024/01/23 16:48:12 by seonjo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -51,7 +51,10 @@ char	**btin_divide_key_and_value(char *env)
 	key_and_value[0] = ft_calloc_s(sizeof(char), (equal_index + 1));
 	i = 0;
 	while (env[i] != '=')
-		key_and_value[0][i++] = env[i];
+	{
+		key_and_value[0][i] = env[i];
+		i++;
+	}
 	key_and_value[1] = ft_strdup_s(env + (equal_index + 1));
 	return (key_and_value);
 }

--- a/btin/btin_make_envsp.c
+++ b/btin/btin_make_envsp.c
@@ -6,7 +6,7 @@
 /*   By: seonjo <seonjo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/16 16:25:24 by seonjo            #+#    #+#             */
-/*   Updated: 2024/01/17 18:35:10 by seonjo           ###   ########.fr       */
+/*   Updated: 2024/01/23 16:21:36 by seonjo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -36,6 +36,7 @@ int	btin_find_equal_index(char *str)
 
 char	**btin_divide_key_and_value(char *env)
 {
+	int		i;
 	int		equal_index;
 	char	**key_and_value;
 
@@ -48,7 +49,9 @@ char	**btin_divide_key_and_value(char *env)
 		return (key_and_value);
 	}
 	key_and_value[0] = ft_calloc_s(sizeof(char), (equal_index + 1));
-	ft_strlcpy(key_and_value[0], env, equal_index + 1);
+	i = 0;
+	while (env[i] != '=')
+		key_and_value[0][i++] = env[i];
 	key_and_value[1] = ft_strdup_s(env + (equal_index + 1));
 	return (key_and_value);
 }

--- a/btin/btin_unset.c
+++ b/btin/btin_unset.c
@@ -6,7 +6,7 @@
 /*   By: seonjo <seonjo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/16 16:26:19 by seonjo            #+#    #+#             */
-/*   Updated: 2024/01/19 15:42:55 by seonjo           ###   ########.fr       */
+/*   Updated: 2024/01/23 16:52:56 by seonjo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -67,7 +67,7 @@ void	btin_remove_envsp_node(t_envs *envsp, char *key)
 		while (next != target)
 		{
 			now = next;
-			next = next->next;
+			next = now->next;
 		}
 		now->next = next->next;
 		free(next->key);
@@ -92,8 +92,10 @@ void	btin_unset(t_cmds *cmds, t_envs *envsp, int fork_flag)
 			btin_remove_envsp_node(envsp, str);
 		else
 		{
+			str = ft_strjoin_s(str, "'");
 			btin_out(0, 0, btin_make_errmsg("minishell: unset: '", \
-				ft_strjoin_s(str, "'"), "not a valid identifier"));
+				str, "not a valid identifier"));
+			free(str);
 			error_flag = 1;
 		}
 	}

--- a/execute/ex_btin_execute.c
+++ b/execute/ex_btin_execute.c
@@ -6,7 +6,7 @@
 /*   By: seonjo <seonjo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/01/19 15:08:04 by seonjo            #+#    #+#             */
-/*   Updated: 2024/01/19 15:46:50 by seonjo           ###   ########.fr       */
+/*   Updated: 2024/01/23 17:02:25 by seonjo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -59,14 +59,12 @@ void	ex_btin_redir_off(int *fd)
 		ex_dup_to(fd[1], 1);
 		close(fd[1]);
 	}
-	free(fd);
 }
 
 int	ex_is_builtin(t_cmds *cmds, t_envs *envsp, int fork_flag)
 {
-	int	*fd;
+	int	fd[2];
 
-	fd = ft_calloc_s(sizeof(int), 2);
 	fd[0] = 0;
 	fd[1] = 1;
 	if (fork_flag == 0)


### PR DESCRIPTION
## Summary
실행부에서 발생하는 메모리 누수 전부 막기 + 사소한 에러 처리

## Description
- leak 막기
    - btin_traverse_list_to_add 함수에서 key_and_value[0]과 key_and_value[1]을 free해주지 않아 leak이 발생했었습니다. 이를 case에 맞게 key_and_value를 free하는 방식으로 고쳤습니다. 
    - btin_export와 btin_unset 에서 에러메시지 출력시 ft_strjoin_s를 사용하여 만든 char *가 free되지 않는 것을 확인했습니다. 따라서 ft_strjoin_s으로 만든 char *를 따로 free 해주는 코드를 추가했습니다.
   
- 사소한 에러 처리
    - btin_divide_key_and_value 에서 ft_strlcpy 함수를 쓰는 것 보다 직접 복사하는 것이 가독성이 좋아보여 수정했습니다.
    - cd 에러메시지에서 cd에서 발생하는 에러를 표시하기 위해 "cd :"를 추가했습니다.
    - btin_atoi에서 오류가 발생할 경우 -1을 출력했었는데 이때 -1이 오류케이스인지 -1이 인자로 들어온건지 알 수 없기 때문에 btin_atoi 오류 발생시 return을 하지 않고 바로 에러메시지 출력후 exit을 하게 만들었습니다.
    - btin_add_new_node 함수를 제정신으로 만들지 않아서 구조가 많이 이상했었습니다. 특히 NULL포인터를 참조하려는 시도가 보였는데 이를 깔끔하게 수정하여 다시 구현했습니다.
      ```c
      void	btin_add_new_node(t_envs *envsp, char **key_and_value)
      {
	      t_envs	*now;
	      t_envs	*next;
      
	      now = envsp;
	      next = now->next;
	      while (next != NULL)
	      {
		      now = next;
		      next = now->next;
	      }
	      now->next = btin_make_envsp_node(key_and_value);
      }
      ```
