### PR TITLE
[FIX] quote의 쌍이 맞지 않을 때, 오류 출력이 bash와 다름

### DIFF
--- a/parser/tk.c
+++ b/parser/tk.c
@@ -29,7 +29,7 @@ static int	tk_meta(char *str, t_token **tk_head, int now)
 	return (len);
 }
 
-static int	tk_word(char *str, t_token **tk_head, int now, int *is_error)
+static int	tk_word(char *str, t_token **tk_head, int now, char *is_error)
 {
 	char	*new_str;
 	int		len;
@@ -47,7 +47,7 @@ static int	tk_word(char *str, t_token **tk_head, int now, int *is_error)
 			if (str[now + len])
 				len++;
 			else
-				*is_error = 1;
+				*is_error = quotes;
 		}
 		else
 			len++;
@@ -62,10 +62,9 @@ int	tk_tokenize(char *str, t_token **tk_head)
 {
 	t_token	*tk_last;
 	int		now;
-	int		is_error;
+	char	is_error;
 
 	is_error = 0;
-	*tk_head = 0;
 	now = 0;
 	while (str[now])
 	{
@@ -79,7 +78,11 @@ int	tk_tokenize(char *str, t_token **tk_head)
 	tk_last = tk_lstlast(*tk_head);
 	tk_last->next = tk_alloc_s(T_NEWLINE, ft_strdup_s("newline"));
 	if (is_error)
+	{
+		printf("minishell: unexpected newline ");
+		printf("while looking for matching `%c\'\n", is_error);
 		return (mktr_print_unexpected("newline"));
+	}
 	else
 		return (0);
 		// return (tk_print(*tk_head));


### PR DESCRIPTION
## Summary
quote의 쌍이 맞지 않을 때, 오류처리가 bash와 다르게 출력된다. bash의 경우 quote를 기다리는 입력이 나오는데, 여기에 EOF(ctrl + d)를 입력하면 그에 맞는 오류 메시지가 출력된다. 따라서 이를 최대한 유사하게 구현하였습니다.

## Description
- 기존의 `*is_error = 1;`를 `*is_error = quotes;`로 수정하고 해당 qoute를 담아서 오류메시지를 출력하도록 구현하였습니다.
