### PR TITLE
[FIX] 실행부 norminette 맞추기

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ a.out
 minishell
 a
 b
+k


### PR DESCRIPTION
## Summary
제가 짠 실행부 코드의 norminette을 맞췄습니다.

## Description
- 멍청하게 브랜치를 파지않고 main에서 작업해버렸습니다 ㅠㅠ 따라서 커밋은 다 main으로 들어갔지만 수정내용은 일단 적겠습니다.


- **Norm 맞춰져있던 파일 리스트**
  - libft_s
  - libft
  - parser 폴더의 mktr_utils.c  tk_utils.c  trtv_wcard.c


- **Norm 처리 완료한 파일 리스트**
  - btin 폴더의 모든 파일
  - execute 폴더의 모든 파일
  - main.c
  - signal_utils.c  
  - parser 폴더의 mktr_heredoc.c  mktr_redirection.c
  - minishell.h

 
- **Norm 처리가 필요한 파일 리스트**
  -  parser 폴더의 mktr.c  tk.c  trtv.c  trtv_env_expand.c  trtv_word_split.c 
