### PR TITLE
[FIX] 환경변수에 value가 nullptr인 경우 segfault 발생 해결

### DIFF
--- a/bon/btin/btin_cd_bonus.c
+++ b/bon/btin/btin_cd_bonus.c
@@ -109,7 +109,7 @@ void	btin_cd(t_cmds *cmds, t_envs *envsp, int fork_flag)
 	if (cmds->argv.items[1] == NULL)
 	{
 		home = btin_find_node(envsp, "HOME");
-		if (home == NULL)
+		if (home == NULL || home->value == NULL)
 		{
 			btin_cd_error(cmds, btin_make_arr(NULL, NULL), 4, fork_flag);
 			return ;

--- a/bon/execute/ex_cmd_loop_bonus.c
+++ b/bon/execute/ex_cmd_loop_bonus.c
@@ -24,7 +24,8 @@ char	**ex_change_to_envp(t_envs *envsp)
 	while (node->next != NULL)
 	{
 		node = node->next;
-		size++;
+		if (node->value != NULL)
+			size++;
 	}
 	envp = ft_calloc_s(sizeof(char *), size + 1);
 	node = envsp;
@@ -32,7 +33,8 @@ char	**ex_change_to_envp(t_envs *envsp)
 	while (i < size)
 	{
 		node = node->next;
-		envp[i++] = ex_strjoin_c(node->key, node->value, '=');
+		if (node->value != NULL)
+			envp[i++] = ex_strjoin_c(node->key, node->value, '=');
 	}
 	envp[i] = NULL;
 	return (envp);

--- a/bon/execute/ex_execute_utils_bonus.c
+++ b/bon/execute/ex_execute_utils_bonus.c
@@ -38,7 +38,7 @@ char	*ex_search_path(t_cmds *cmds, t_envs *envsp, char *cmd, int i)
 
 	while (envsp != NULL && ft_strncmp(envsp->key, "PATH", 5) != 0)
 		envsp = envsp->next;
-	if (envsp == NULL)
+	if (envsp == NULL || envsp->value == NULL)
 		btin_out(1, 127, btin_make_errmsg("minishell: ", cmd, \
 			"No such file or directory"), cmds->enop);
 	envp_path = ft_split_s(envsp->value, ':');

--- a/bon/parser/parser_set_bonus.c
+++ b/bon/parser/parser_set_bonus.c
@@ -26,7 +26,7 @@ void	parser_info_init(int argc, char **argv, t_parser_info *p_info)
 	printf("\t███   ███   ███ ███  ███   ███ ███          ███  ███    ███  \n");
 	printf("\t███   ███   ███ ███  ███   ███ ███  ▄██     ███  ███    ███  \n");
 	printf("\t ▀█   ███   █▀  █▀    ▀█   █▀  █▀   ▀████████▀    ▀█    █▀   \n");
-	printf("\n\t                version: 1.17 [2024.01.28]\n");
+	printf("\n\t                version: 1.18 [2024.01.29]\n");
 	printf("\t                   by michang & seonjo\n\n");
 }
 

--- a/bon/parser/trtv_env_expand_bonus.c
+++ b/bon/parser/trtv_env_expand_bonus.c
@@ -24,8 +24,11 @@ static void	trtv_dollar_to_value(char *word, char **e_w, t_envs *envsp, int len)
 		free(key);
 		return ;
 	}
-	value = ft_strdup_s(btin_find_node(envsp, key)->value);
+	value = btin_find_node(envsp, key)->value;
 	free(key);
+	if (!value)
+		return ;
+	value = ft_strdup_s(value);
 	i = 0;
 	while (value[i])
 	{

--- a/src/btin/btin_cd.c
+++ b/src/btin/btin_cd.c
@@ -109,7 +109,7 @@ void	btin_cd(t_cmds *cmds, t_envs *envsp, int fork_flag)
 	if (cmds->argv.items[1] == NULL)
 	{
 		home = btin_find_node(envsp, "HOME");
-		if (home == NULL)
+		if (home == NULL || home->value == NULL)
 		{
 			btin_cd_error(cmds, btin_make_arr(NULL, NULL), 4, fork_flag);
 			return ;

--- a/src/execute/ex_cmd_loop.c
+++ b/src/execute/ex_cmd_loop.c
@@ -24,7 +24,8 @@ char	**ex_change_to_envp(t_envs *envsp)
 	while (node->next != NULL)
 	{
 		node = node->next;
-		size++;
+		if (node->value != NULL)
+			size++;
 	}
 	envp = ft_calloc_s(sizeof(char *), size + 1);
 	node = envsp;
@@ -32,7 +33,8 @@ char	**ex_change_to_envp(t_envs *envsp)
 	while (i < size)
 	{
 		node = node->next;
-		envp[i++] = ex_strjoin_c(node->key, node->value, '=');
+		if (node->value != NULL)
+			envp[i++] = ex_strjoin_c(node->key, node->value, '=');
 	}
 	envp[i] = NULL;
 	return (envp);

--- a/src/execute/ex_execute_utils.c
+++ b/src/execute/ex_execute_utils.c
@@ -38,7 +38,7 @@ char	*ex_search_path(t_cmds *cmds, t_envs *envsp, char *cmd, int i)
 
 	while (envsp != NULL && ft_strncmp(envsp->key, "PATH", 5) != 0)
 		envsp = envsp->next;
-	if (envsp == NULL)
+	if (envsp == NULL || envsp->value == NULL)
 		btin_out(1, 127, btin_make_errmsg("minishell: ", cmd, \
 			"No such file or directory"), cmds->enop);
 	envp_path = ft_split_s(envsp->value, ':');

--- a/src/parser/parser_set.c
+++ b/src/parser/parser_set.c
@@ -26,7 +26,7 @@ void	parser_info_init(int argc, char **argv, t_parser_info *p_info)
 	printf("\t███   ███   ███ ███  ███   ███ ███          ███  ███    ███  \n");
 	printf("\t███   ███   ███ ███  ███   ███ ███  ▄██     ███  ███    ███  \n");
 	printf("\t ▀█   ███   █▀  █▀    ▀█   █▀  █▀   ▀████████▀    ▀█    █▀   \n");
-	printf("\n\t                version: 1.17 [2024.01.28]\n");
+	printf("\n\t                version: 1.18 [2024.01.29]\n");
 	printf("\t                   by michang & seonjo\n\n");
 }
 

--- a/src/parser/trtv_env_expand.c
+++ b/src/parser/trtv_env_expand.c
@@ -24,8 +24,11 @@ static void	trtv_dollar_to_value(char *word, char **e_w, t_envs *envsp, int len)
 		free(key);
 		return ;
 	}
-	value = ft_strdup_s(btin_find_node(envsp, key)->value);
+	value = btin_find_node(envsp, key)->value;
 	free(key);
+	if (!value)
+		return ;
+	value = ft_strdup_s(value);
 	i = 0;
 	while (value[i])
 	{


### PR DESCRIPTION
## Summary
환경변수를 unset하고 export로 이름만 선언한 경우 value가 nullptr이 되고, 이에 따른 다양한 segfault가 발생하는 것을 방지했습니다.

## Description
- value가 nullptr인 경우를 모두 고려하여 방어해주었습니다.